### PR TITLE
Overwrite HAML template to add footer with copyright

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,12 +48,32 @@ download {
     outputs.dir deckjsDir
 }
 
+task overwriteHamlTemplate {
+    doLast {
+        def documentTemplate = new File(templateDir, 'haml/document.html.haml')
+        def template = documentTemplate.text
+        
+        if (!template.contains('%footer(class="copyright")')) {
+            documentTemplate.withPrintWriter { writer ->
+                template.eachLine { line ->
+                    writer.println line
+                    if (line ==~ /\s+\.deck-container/) {
+                        writer.println '      %footer(class="copyright")'
+                        writer.println '        %img{:src=> image_uri("logo-circle.png"), :width=> "40", :align=> "left"} &copy; 2017 Object Computing Inc.'
+                    }
+                }
+            }
+        }
+    }   
+}
+overwriteHamlTemplate.dependsOn download
+
 asciidoctorj {
     version = '1.5.5'
 }
 
 asciidoctor {
-    dependsOn jrubyPrepare
+    dependsOn jrubyPrepare, overwriteHamlTemplate
 
     sources {
         include 'index.adoc'
@@ -63,12 +83,15 @@ asciidoctor {
         from (sourceDir) {
             include 'images/**'
         }
+        from ('src/docs') {
+            include 'theme/**'
+        }
         from (downloadDir) {
             include 'deck.js/**'
         }
     }
 
-    backends 'html5'
+    backends 'deckjs'
 
     attributes \
         'build-gradle': file('build.gradle'),
@@ -81,7 +104,9 @@ asciidoctor {
         'setanchors': '',
         'idprefix': '',
         'idseparator': '-',
-        'docinfo1': ''
+        'docinfo1': '',
+        'customcss': 'theme/fonts.css',
+        'status': ''
 
     options template_dirs : [new File(templateDir,'haml').absolutePath ]
 

--- a/src/docs/theme/fonts.css
+++ b/src/docs/theme/fonts.css
@@ -10,3 +10,11 @@
     font-style: normal;
 
 }
+
+footer {
+    position:absolute;
+    bottom:0;
+    width:100%;
+    height:40px;
+    padding: 10px;
+}


### PR DESCRIPTION
The docinfo document attributes in Asciidoctor are only for the Dockbook and HTML5 templates that are built-in. This is a solution where the HAML template for deckjs is changed to include a footer with copyright.